### PR TITLE
Add AI-based complaint categorization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn==23.0.0
 Jinja2==3.1.6
 requests==2.32.4
 Werkzeug
+scikit-learn==1.5.1

--- a/setup/complaint_training_data.csv
+++ b/setup/complaint_training_data.csv
@@ -1,0 +1,6 @@
+complaint,category
+"Internet speed is very slow today",Speed Issue
+"No internet connection since morning",Connection Down
+"Charged extra on my last bill",Billing
+"Need help installing the new router",Installation
+"I have a general question",Other

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -717,8 +717,8 @@ body.dark-mode .step::after {
 .data-table td:nth-child(4),
 .data-table td:nth-child(6),
 .data-table td:nth-child(7),
-.data-table td:nth-child(8),
-.data-table td:nth-child(9) {
+.data-table td:nth-child(9),
+.data-table td:nth-child(10) {
     white-space: nowrap;
 }
 
@@ -740,6 +740,22 @@ body.dark-mode .step::after {
 
 .source-badge.whatsapp {
     background-color: #25D366;
+}
+
+/* ===== CATEGORY BADGE COLORS ===== */
+.category-speed-issue { background-color: #FF9800; }
+.category-connection-down { background-color: #e74c3c; }
+.category-billing { background-color: #007BFF; }
+.category-installation { background-color: #2ecc71; }
+.category-other { background-color: #7f8c8d; }
+
+/* ===== CATEGORY FILTER BUTTONS ===== */
+.category-filters {
+    margin-bottom: 10px;
+}
+.category-filters .button {
+    margin-top: 0;
+    margin-right: 5px;
 }
 
 /* ===== RESPONSIVE ADJUSTMENTS ===== */

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -43,6 +43,12 @@
 
     <div class="table-section centered-card recent-complaints-card">
         <h2 class="section-title text-center w-full">Recent Complaints</h2>
+        <div class="category-filters">
+            <button type="button" class="button filter-btn" data-category="All">All</button>
+            {% for cat in categories %}
+            <button type="button" class="button filter-btn" data-category="{{ cat }}">{{ cat }}</button>
+            {% endfor %}
+        </div>
         <form id="bulkActionForm" method="POST">
             <div class="bulk-buttons recent-complaints-actions">
                 <button type="submit"
@@ -67,6 +73,7 @@
                         <col style="width:120px;">
                         <col style="width:130px;">
                         <col style="width:260px;">
+                        <col style="width:120px;">
                         <col style="width:110px;">
                         <col style="width:80px;">
                         <col style="width:100px;">
@@ -79,6 +86,7 @@
                             <th>Name</th>
                             <th>Mobile</th>
                             <th>Complaint</th>
+                            <th>Category</th>
                             <th>Status</th>
                             <th>Priority</th>
                             <th>Source</th>
@@ -89,12 +97,15 @@
                         {% for comp in recent_complaints %}
                         {% set src = comp['source'] %}
                         {% if src != 'Webhook' %}
-                        <tr>
+                        <tr data-category="{{ comp['category'] }}">
                             <td><input type="checkbox" name="selected_ids[]" value="{{ comp['id'] }}"></td>
                             <td>{{ comp['id'] }}</td>
                             <td>{{ comp['name'] }}</td>
                             <td>{{ comp['mobile'] }}</td>
                             <td class="td-complaint" title="{{ comp['complaint'] }}">{{ comp['complaint'] }}</td>
+                            <td>
+                                <span class="badge category-{{ comp['category']|lower|replace(' ', '-') }}">{{ comp['category'] }}</span>
+                            </td>
                             <td>{{ comp['status'] }}</td>
                             <td>{{ comp['priority'] }}</td>
                             <td>
@@ -214,6 +225,19 @@
     document.getElementById('selectAll').addEventListener('click', function () {
         const checkboxes = document.querySelectorAll('input[name="selected_ids[]"]');
         checkboxes.forEach(cb => cb.checked = this.checked);
+    });
+    document.querySelectorAll('.filter-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const category = btn.getAttribute('data-category');
+            document.querySelectorAll('.recent-complaints-table tbody tr').forEach(row => {
+                const rowCat = row.getAttribute('data-category');
+                if (category === 'All' || rowCat === category) {
+                    row.style.display = '';
+                } else {
+                    row.style.display = 'none';
+                }
+            });
+        });
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- integrate scikit-learn model for automatic complaint category prediction
- store predicted categories in the database and train from sample data when model file is missing
- include initial training dataset for model bootstrap
- display category badges on dashboard with client-side category filtering

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement scikit-learn==1.5.1)*
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f41963e50833286306e74a783042b