### PR TITLE
Enhance network status section with named IP cards

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -241,6 +241,56 @@ input:checked + .slider:before {
     color: #007BFF;
 }
 
+/* ===== NETWORK STATUS SECTION ===== */
+#ip-status-list {
+    display: grid;
+    gap: 12px;
+}
+
+.status-card {
+    display: flex;
+    align-items: center;
+    padding: 10px 12px;
+    background: #f3f4f6; /* gray-100 */
+    border: 1px solid #e5e7eb; /* gray-200 */
+    border-radius: 8px;
+}
+
+.status-card .server-icon {
+    font-size: 20px;
+    margin-right: 10px;
+    color: #6b7280; /* gray-500 */
+}
+
+.status-card .server-name {
+    font-weight: 600;
+}
+
+.status-card .server-ip {
+    font-size: 13px;
+    color: #6b7280; /* gray-500 */
+}
+
+.status-card .status-icon {
+    margin-left: auto;
+    font-size: 18px;
+}
+
+.status-card.up {
+    background-color: #dcfce7; /* green-100 */
+    border-color: #16a34a; /* green-600 */
+}
+
+.status-card.down {
+    background-color: #fee2e2; /* red-100 */
+    border-color: #dc2626; /* red-600 */
+}
+
+#networkChart {
+    width: 100% !important;
+    height: 100% !important;
+}
+
 /* Responsive fix for smaller screens */
 @media (max-width: 768px) {
     .topnav {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -31,11 +31,37 @@
 {% block content %}
     <section class="bg-white rounded shadow p-4 mb-6">
         <h2 class="section-title mb-2">Network Status</h2>
-        <ul id="ip-status-list" class="space-y-1">
-            <li data-ip="103.149.126.10">103.149.126.10 <i class="fas fa-circle-notch fa-spin"></i></li>
-            <li data-ip="36.50.163.244">36.50.163.244 <i class="fas fa-circle-notch fa-spin"></i></li>
-            <li data-ip="154.84.251.178">154.84.251.178 <i class="fas fa-circle-notch fa-spin"></i></li>
-        </ul>
+        <div class="flex flex-col sm:flex-row sm:items-start sm:space-x-8">
+            <div id="ip-status-list" class="flex-1 grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <div class="status-card" data-ip="103.149.126.10">
+                    <i class="fas fa-server server-icon"></i>
+                    <div class="server-info">
+                        <div class="server-name">Vishrantwadi</div>
+                        <div class="server-ip">103.149.126.10</div>
+                    </div>
+                    <i class="status-icon fas fa-circle-notch fa-spin"></i>
+                </div>
+                <div class="status-card" data-ip="36.50.163.244">
+                    <i class="fas fa-server server-icon"></i>
+                    <div class="server-info">
+                        <div class="server-name">Dhanori</div>
+                        <div class="server-ip">36.50.163.244</div>
+                    </div>
+                    <i class="status-icon fas fa-circle-notch fa-spin"></i>
+                </div>
+                <div class="status-card" data-ip="154.84.251.178">
+                    <i class="fas fa-server server-icon"></i>
+                    <div class="server-info">
+                        <div class="server-name">Tingrenagar</div>
+                        <div class="server-ip">154.84.251.178</div>
+                    </div>
+                    <i class="status-icon fas fa-circle-notch fa-spin"></i>
+                </div>
+            </div>
+            <div class="mt-4 sm:mt-0 w-full sm:w-48 h-32">
+                <canvas id="networkChart"></canvas>
+            </div>
+        </div>
     </section>
 
     <section class="stats grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
@@ -220,6 +246,27 @@
             maintainAspectRatio: false
         }
     });
+
+    const networkCtx = document.getElementById('networkChart').getContext('2d');
+    const networkChart = new Chart(networkCtx, {
+        type: 'doughnut',
+        data: {
+            labels: ['Up', 'Down'],
+            datasets: [{
+                data: [0, 0],
+                backgroundColor: ['#16A34A', '#DC2626'],
+                borderWidth: 0
+            }]
+        },
+        options: {
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    position: 'bottom'
+                }
+            }
+        }
+    });
     const toggle = document.getElementById('themeToggle');
     const body = document.body;
     const theme = localStorage.getItem('theme');
@@ -253,13 +300,26 @@
         try {
             const res = await fetch('{{ url_for('ping_status') }}');
             const data = await res.json();
-            Object.entries(data).forEach(([ip, isUp]) => {
-                const icon = document.querySelector(`#ip-status-list li[data-ip="${ip}"] i`);
-                if (!icon) return;
-                icon.className = isUp
-                    ? 'fas fa-check-circle text-green-500'
-                    : 'fas fa-times-circle text-red-500';
+            let up = 0, down = 0;
+            Object.entries(data).forEach(([ip, status]) => {
+                const card = document.querySelector(`#ip-status-list [data-ip="${ip}"]`);
+                const icon = card ? card.querySelector('.status-icon') : null;
+                if (!card || !icon) return;
+                card.classList.remove('up', 'down');
+                if (status === 'Online') {
+                    icon.className = 'status-icon fas fa-check-circle text-green-500';
+                    card.classList.add('up');
+                    up++;
+                } else if (status === 'Offline') {
+                    icon.className = 'status-icon fas fa-times-circle text-red-500';
+                    card.classList.add('down');
+                    down++;
+                } else {
+                    icon.className = 'status-icon fas fa-question-circle text-gray-500';
+                }
             });
+            networkChart.data.datasets[0].data = [up, down];
+            networkChart.update();
         } catch (err) {
             console.error('Failed to update IP status', err);
         }


### PR DESCRIPTION
## Summary
- Replace simple IP list with styled cards showing location names and addresses
- Highlight card background based on up/down status via updated script
- Style network status cards for a more engaging layout

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab319d2a348332aa88ab4ab6c9fd04