### PR TITLE
Center header title and hide network chart labels

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -21,6 +21,7 @@ h1, h2 {
     background-color: #ffffff;
     border-bottom: 1px solid #ddd;
     flex-wrap: wrap;
+    position: relative;
 }
 
 .header .logo {
@@ -35,7 +36,9 @@ h1, h2 {
 }
 
 .header .title {
-    flex: 1;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
     text-align: center;
     font-size: 22px;
     font-weight: bold;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -257,7 +257,6 @@
     const networkChart = new Chart(networkCtx, {
         type: 'doughnut',
         data: {
-            labels: ['Up', 'Down'],
             datasets: [{
                 data: [0, 0],
                 backgroundColor: ['#16A34A', '#DC2626'],
@@ -268,7 +267,7 @@
             maintainAspectRatio: false,
             plugins: {
                 legend: {
-                    position: 'bottom'
+                    display: false
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Center the `COUNTRYLINK BROADBAND` header title regardless of side content
- Hide the legend labels on the network status doughnut chart

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ab4076b4948332b6fc955ba4f5ed9e