### PR TITLE
Hide header title on small screens to prevent overlap

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -45,6 +45,13 @@ h1, h2 {
     color: #333;
 }
 
+/* Hide header title on mobile and tablet to prevent overlap with logo */
+@media (max-width: 1024px) {
+    .header .title {
+        display: none;
+    }
+}
+
 .header .language,
 .header .theme-toggle {
     display: flex;


### PR DESCRIPTION
## Summary
- Add responsive CSS rule to hide "COUNTRYLINK BROADBAND" header title on screens 1024px and below.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab4e4aa0b483329ab2053ba74ead5b