### PR TITLE
Fix recent complaints alignment and mobile layout

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -683,6 +683,7 @@ body.dark-mode .step::after {
     flex-direction: column;
     align-items: center;
     overflow-x: auto;             /* Horizontal scroll only if content overflows */
+    box-sizing: border-box;       /* Ensure padding doesn't shift width */
 }
 
 .recent-complaints-card {
@@ -693,6 +694,12 @@ body.dark-mode .step::after {
 
 .centered-card form {
     width: 100%;
+}
+
+/* Make table wrapper responsive */
+.table-responsive {
+    width: 100%;
+    overflow-x: auto;
 }
 
 /* ===== BULK BUTTONS ===== */

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -79,7 +79,7 @@
         </div>
     </section>
 
-    <div class="table-section centered-card recent-complaints-card">
+    <div class="table-section centered-card recent-complaints-card w-full">
         <div class="recent-complaints-header">
             <h2 class="section-title">Recent Complaints</h2>
             <div class="category-filters">
@@ -105,7 +105,7 @@
                     Delete
                 </button>
             </div>
-            <div class="table-responsive">
+            <div class="table-responsive w-full">
                 <table class="data-table recent-complaints-table">
                     <colgroup>
                         <col style="width:40px;">


### PR DESCRIPTION
## Summary
- Prevent dashboard recent complaints card from shifting by including padding in width calculation
- Ensure recent complaints table occupies full width and is scrollable on small screens

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac90e634e88332871b8b015d604b2b