### PR TITLE
Add mobile sidebar navigation to dashboard

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -142,6 +142,46 @@ input:checked + .slider:before {
     background-color: #e0e0e0;
 }
 
+/* ===== MOBILE MENU BUTTON ===== */
+.menu-button {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+@media (max-width: 768px) {
+    .menu-button {
+        display: block;
+        margin-right: 10px;
+    }
+
+    .tabs {
+        display: none;
+        flex-direction: column;
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 200px;
+        background-color: #ffffff;
+        padding-top: 60px;
+        box-shadow: 2px 0 5px rgba(0,0,0,0.1);
+        z-index: 1000;
+    }
+
+    .tabs.open {
+        display: flex;
+    }
+
+    .tab {
+        border-right: none;
+        border-bottom: 1px solid #ccc;
+        text-align: left;
+    }
+}
+
 /* ===== FIX FOR NAVBAR SECTION IN track.html ===== */
 .navbar {
     display: flex;

--- a/static/js/menu.js
+++ b/static/js/menu.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const menuButton = document.getElementById('menuButton');
+    const nav = document.getElementById('mainNav');
+    if (menuButton && nav) {
+        menuButton.addEventListener('click', function () {
+            nav.classList.toggle('open');
+        });
+    }
+});

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -12,6 +12,7 @@
 </head>
 <body class="bg-gray-50 font-roboto">
     <header class="header">
+        <button id="menuButton" class="menu-button"><i class="fas fa-bars"></i></button>
         <div class="logo">
             <a href="{{ url_for('dashboard') }}">
                 <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Countrylink Logo">
@@ -22,12 +23,13 @@
             {% block header_actions %}{% endblock %}
         </div>
     </header>
-    <nav class="tabs">
+    <nav class="tabs" id="mainNav">
         {% block tabs %}{% endblock %}
     </nav>
     <main class="container mx-auto p-4">
         {% block content %}{% endblock %}
     </main>
+    <script src="{{ url_for('static', filename='js/menu.js') }}"></script>
     {% block extra_scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add hamburger menu and sidebar navigation for mobile screens
- Style responsive sidebar and menu button
- Implement small script to toggle sidebar visibility

## Testing
- `python -m py_compile app.py auth.py setup/create_db.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac95222bd08332b8588dc97f7ce4da