### PR TITLE
Enhance mobile dashboard sidebar with chart and overlay

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -122,19 +122,21 @@ input:checked + .slider:before {
     flex-wrap: wrap;
 }
 
-.tab {
-    padding: 12px 16px;
-    text-align: center;
-    cursor: pointer;
-    flex-grow: 1;
-    font-weight: bold;
-    border-right: 1px solid #ccc;
+.tab { 
+    padding: 12px 16px; 
+    text-align: center; 
+    cursor: pointer; 
+    flex-grow: 1; 
+    font-weight: bold; 
+    border-right: 1px solid #ccc; 
 }
 
 .tab a {
     text-decoration: none;
     color: #333;
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .tab:hover,
@@ -158,28 +160,54 @@ input:checked + .slider:before {
     }
 
     .tabs {
-        display: none;
         flex-direction: column;
         position: fixed;
         top: 0;
         left: 0;
         height: 100%;
-        width: 200px;
-        background-color: #ffffff;
+        width: 220px;
+        background: #1f2937;
+        color: #fff;
         padding-top: 60px;
-        box-shadow: 2px 0 5px rgba(0,0,0,0.1);
+        box-shadow: 2px 0 8px rgba(0,0,0,0.2);
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
         z-index: 1000;
+        display: flex;
     }
 
     .tabs.open {
-        display: flex;
+        transform: translateX(0);
     }
 
     .tab {
         border-right: none;
-        border-bottom: 1px solid #ccc;
+        border-bottom: 1px solid rgba(255,255,255,0.1);
         text-align: left;
     }
+
+    .tab a {
+        color: #fff;
+    }
+
+    .sidebar-chart-container {
+        padding: 1rem;
+    }
+}
+
+.sidebar-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 500;
+}
+
+.sidebar-overlay.show {
+    display: block;
 }
 
 /* ===== FIX FOR NAVBAR SECTION IN track.html ===== */

--- a/static/js/menu.js
+++ b/static/js/menu.js
@@ -1,9 +1,15 @@
 document.addEventListener('DOMContentLoaded', function () {
     const menuButton = document.getElementById('menuButton');
     const nav = document.getElementById('mainNav');
-    if (menuButton && nav) {
+    const overlay = document.getElementById('sidebarOverlay');
+    if (menuButton && nav && overlay) {
         menuButton.addEventListener('click', function () {
             nav.classList.toggle('open');
+            overlay.classList.toggle('show');
+        });
+        overlay.addEventListener('click', function () {
+            nav.classList.remove('open');
+            overlay.classList.remove('show');
         });
     }
 });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -21,6 +21,9 @@
     </a>
 {% endblock %}
 {% block tabs %}
+    <div class="sidebar-chart-container">
+        <canvas id="sidebarChart"></canvas>
+    </div>
     <div class="tab active"><a href="{{ url_for('dashboard') }}"><i class="fas fa-gauge"></i> Dashboard</a></div>
     <div class="tab"><a href="{{ url_for('complaints_page') }}"><i class="fas fa-code-branch"></i> Complaints</a></div>
     <div class="tab"><a href="{{ url_for('new_connections') }}"><i class="fas fa-user-plus"></i> New Connections</a></div>
@@ -251,6 +254,31 @@
             maintainAspectRatio: false
         }
     });
+
+    const sidebarCtx = document.getElementById('sidebarChart');
+    if (sidebarCtx) {
+        new Chart(sidebarCtx, {
+            type: 'bar',
+            data: {
+                labels: ['Pending', 'Resolved'],
+                datasets: [{
+                    data: [{{ pending }}, {{ resolved }}],
+                    backgroundColor: ['#FF6384', '#36A2EB']
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false }
+                },
+                scales: {
+                    x: { display: false },
+                    y: { display: false }
+                }
+            }
+        });
+    }
 
     const toggle = document.getElementById('themeToggle');
     const body = document.body;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -26,6 +26,7 @@
     <nav class="tabs" id="mainNav">
         {% block tabs %}{% endblock %}
     </nav>
+    <div id="sidebarOverlay" class="sidebar-overlay"></div>
     <main class="container mx-auto p-4">
         {% block content %}{% endblock %}
     </main>


### PR DESCRIPTION
## Summary
- style mobile sidebar with slide-in dark theme and overlay
- add mini bar chart and icon alignment in sidebar navigation
- toggle overlay with menu button

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found; installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68ac991de118833287c50a050ee540c6