### PR TITLE
Fix ping status reporting for dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -211,15 +211,8 @@ def before_request():
 @app.route('/ping-status')
 @login_required
 def ping_status():
-    """Return normalized ping results as Online / Offline / Error."""
-    statuses = {}
-    for ip, result in ping_results.items():
-        if result == "Online":
-            statuses[ip] = "Online"
-        elif result == "Offline":
-            statuses[ip] = "Offline"
-        else:
-            statuses[ip] = "Error"
+    """Return boolean status for each IP (True = online)."""
+    statuses = {ip: (result == "Online") for ip, result in ping_results.items()}
     return jsonify(statuses)
 
 # ==============================


### PR DESCRIPTION
## Summary
- return boolean IP statuses in `/ping-status` so frontend correctly marks offline hosts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a9291ed48332a512e8921113142f