### PR TITLE
Fix mobile header layout in payment checkout page

### DIFF
--- a/templates/payment.html
+++ b/templates/payment.html
@@ -479,11 +479,39 @@
     ::-webkit-scrollbar-thumb{background:var(--surface2);border-radius:3px;}
 
     @media(max-width:960px){.main-content{grid-template-columns:1fr;}.right-panel{position:static;}}
+    @media(max-width:767px){
+      .header{
+        position:relative;
+        justify-content:center;
+        padding-left:64px;
+        padding-right:150px;
+      }
+      .back-btn{
+        position:absolute;
+        left:16px;
+        top:50%;
+        transform:translateY(-50%);
+      }
+      .logo{
+        margin:0 auto;
+        text-align:center;
+      }
+      .secure-badge{
+        position:absolute;
+        right:16px;
+        top:50%;
+        transform:translateY(-50%);
+        padding:5px 10px;
+        gap:6px;
+        font-size:0.66rem;
+        letter-spacing:0.05em;
+      }
+    }
     @media(max-width:560px){
       .container{padding:0 14px 48px;}
-      .header{padding:14px 16px;gap:10px;}
+      .header{padding:14px 120px 14px 60px;gap:10px;}
       .logo img{height:34px;}
-      .secure-badge{padding:6px 12px;font-size:0.64rem;letter-spacing:0.06em;}
+      .secure-badge{padding:4px 8px;font-size:0.64rem;letter-spacing:0.04em;}
       .secure-dot{width:6px;height:6px;}
       .cycle-btn{padding:8px 10px;font-size:0.76rem;}
       .section-card{padding:18px;}


### PR DESCRIPTION
### Motivation
- The header logo could be pushed off-center on narrow screens by the left back arrow and the right "Secure Checkout" badge. 
- The goal is to center the logo while keeping the back button on the left and the secure badge on the right without affecting layout.

### Description
- Added an `@media (max-width: 767px)` block in `templates/payment.html` to set `.header { position: relative; justify-content: center; padding-left: 64px; padding-right: 150px; }` so the header acts as a positioning container. 
- Made `.back-btn` `position: absolute` and left-aligned with vertical centering, and made `.secure-badge` `position: absolute` on the right with reduced `font-size` and `padding` to keep it compact. 
- Tuned the existing `@media (max-width: 560px)` rules to increase left/right header padding and further reduce `.secure-badge` padding to avoid overlap on very small screens. 
- Changes applied to `templates/payment.html`.

### Testing
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff5864554832a95c2ce595fbb51fd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive checkout layout for mobile and tablet devices with optimized header positioning and spacing to enhance the payment experience on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->