### PR TITLE
Improve mobile responsive header and layout in payment template

### DIFF
--- a/templates/payment.html
+++ b/templates/payment.html
@@ -479,11 +479,40 @@
     ::-webkit-scrollbar-thumb{background:var(--surface2);border-radius:3px;}
 
     @media(max-width:960px){.main-content{grid-template-columns:1fr;}.right-panel{position:static;}}
+    @media(max-width:767px){
+      .header{
+        position:relative;
+        justify-content:center;
+        padding-left:64px;
+        padding-right:72px;
+      }
+      .back-btn{
+        position:absolute;
+        left:16px;
+        top:50%;
+        transform:translateY(-50%);
+      }
+      .logo{
+        margin:0 auto;
+        text-align:center;
+      }
+      .secure-badge{
+        position:absolute;
+        right:16px;
+        top:50%;
+        transform:translateY(-50%);
+        padding:6px;
+        min-width:auto;
+      }
+      .secure-badge span{
+        display:none;
+      }
+    }
     @media(max-width:560px){
       .container{padding:0 14px 48px;}
-      .header{padding:14px 16px;gap:10px;}
-      .logo img{height:34px;}
-      .secure-badge{padding:6px 12px;font-size:0.64rem;letter-spacing:0.06em;}
+      .header{padding:14px 72px 14px 60px;gap:10px;}
+      .logo img{height:36px;}
+      .secure-badge{padding:5px;}
       .secure-dot{width:6px;height:6px;}
       .cycle-btn{padding:8px 10px;font-size:0.76rem;}
       .section-card{padding:18px;}


### PR DESCRIPTION
### Motivation
- Adjust the payment page header and related UI elements to display and align correctly on narrow screens (≤767px and ≤560px). 

### Description
- Add `@media(max-width:767px)` rules to center the header, set it `position:relative`, and position the back button and secure badge absolutely for consistent alignment. 
- Center the logo and hide the secure badge text on very small screens by collapsing the badge span, and vertically center the back button and badge with `transform:translateY(-50%)`. 
- Update `@media(max-width:560px)` header padding, increase the `.logo img` height to `36px`, and reduce `.secure-badge` padding to improve spacing on very small devices. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff5864554832a95c2ce595fbb51fd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive design for the payment checkout page with optimized header element positioning and spacing on mobile and tablet devices for better visual presentation and usability on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->