### PR TITLE
Fix dashboard crash when legacy DB lacks created_at columns

### DIFF
--- a/app.py
+++ b/app.py
@@ -1389,6 +1389,11 @@ def init_db():
         c.execute("ALTER TABLE complaints ADD COLUMN category TEXT DEFAULT 'Other'")
     except sqlite3.OperationalError:
         pass
+    try:
+        c.execute("ALTER TABLE complaints ADD COLUMN created_at TEXT")
+    except sqlite3.OperationalError:
+        pass
+    c.execute("UPDATE complaints SET created_at = COALESCE(created_at, CURRENT_TIMESTAMP)")
 
     c.execute('''
         CREATE TABLE IF NOT EXISTS whatsapp_messages (
@@ -1494,6 +1499,11 @@ def init_db():
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
     ''')
+    try:
+        c.execute("ALTER TABLE connection_requests ADD COLUMN created_at TEXT")
+    except sqlite3.OperationalError:
+        pass
+    c.execute("UPDATE connection_requests SET created_at = COALESCE(created_at, CURRENT_TIMESTAMP)")
 
     c.execute('''CREATE TABLE IF NOT EXISTS stock (
         id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
### Motivation
- Production logs showed `/dashboard` failing with `sqlite3.OperationalError: no such column: created_at`, indicating older SQLite schemas missing expected timestamp columns. 
- The dashboard and several queries assume `created_at` exists on `complaints` and `connection_requests`, so the app must repair legacy schemas at startup to avoid runtime errors.

### Description
- Added an idempotent migration in `init_db()` to `ALTER TABLE complaints ADD COLUMN created_at TEXT` inside a `try/except` and backfill nulls with `UPDATE complaints SET created_at = COALESCE(created_at, CURRENT_TIMESTAMP)`. 
- Applied the same defensive `ALTER TABLE` + `UPDATE` pattern for `connection_requests.created_at` to prevent similar failures in connection widgets. 
- Changes are implemented in `app.py` and designed to be safe to run repeatedly (no-op when columns already exist).

### Testing
- Ran `python -m py_compile app.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00154a7c8832aa0f02ff453b80391)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured database records contain proper timestamp information across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->