### PR TITLE
Fix Passenger recursion and restore dashboard bulk action endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1814,6 +1814,51 @@ def update_status(complaint_id, status):
     return redirect(url_for('dashboard'))
 
 
+
+
+@app.route('/update_complaints_bulk', methods=['POST'])
+@login_required
+def update_complaints_bulk():
+    action = (request.form.get('action') or '').strip().lower()
+    selected_ids = request.form.getlist('selected_ids[]')
+
+    valid_ids = []
+    for complaint_id in selected_ids:
+        try:
+            valid_ids.append(int(complaint_id))
+        except (TypeError, ValueError):
+            continue
+
+    if not valid_ids:
+        flash('No complaints selected.', 'warning')
+        return redirect(url_for('dashboard'))
+
+    placeholders = ','.join('?' for _ in valid_ids)
+    conn = get_db_connection()
+    c = conn.cursor()
+
+    if action == 'resolve':
+        c.execute(
+            f"UPDATE complaints SET status = 'Resolved' WHERE id IN ({placeholders})",
+            valid_ids
+        )
+        flash(f"Marked {c.rowcount} complaint(s) as resolved.", 'success')
+    elif action == 'delete':
+        c.execute(
+            f"DELETE FROM complaints WHERE id IN ({placeholders})",
+            valid_ids
+        )
+        flash(f"Deleted {c.rowcount} complaint(s).", 'success')
+    else:
+        conn.close()
+        flash('Invalid bulk action.', 'error')
+        return redirect(url_for('dashboard'))
+
+    conn.commit()
+    conn.close()
+    return redirect(url_for('dashboard'))
+
+
 @app.route('/webhook', methods=['GET', 'POST'])
 @app.route('/webhook/whatsapp', methods=['GET', 'POST'])
 def webhook():

--- a/passenger_wsgi.py
+++ b/passenger_wsgi.py
@@ -1,3 +1,18 @@
-import sys, os
-sys.path.insert(0, os.path.dirname(__file__))
-from app import app as application
+"""WSGI entrypoint for Passenger.
+
+Avoid importing this file via imp.load_source, which can recurse indefinitely
+if the source path also points to passenger_wsgi.py.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+# Passenger looks for `application` by default.
+from app import app as application  # noqa: E402


### PR DESCRIPTION
### Motivation
- Prevent a production `RecursionError` caused by recursive loading of `passenger_wsgi.py` and fix dashboard 500s caused by a missing bulk-action endpoint referenced from `templates/dashboard.html`.

### Description
- Update `passenger_wsgi.py` to set the project path and import the Flask app directly via `from app import app as application` to avoid `imp.load_source` self-import recursion.
- Add `@app.route('/update_complaints_bulk', methods=['POST'])` in `app.py` that validates `selected_ids[]`, supports `resolve` and `delete` actions, uses `?` placeholders for safe SQL execution, and returns users to the `dashboard` with `flash` messages.
- Ensure templates no longer reference unresolved endpoints so `url_for(...)` calls can build successfully.

### Testing
- Ran `python -m py_compile app.py passenger_wsgi.py` which completed successfully.
- Executed an endpoint-audit script that inspects `app.url_map` and scans templates for `url_for(...)` references and found no unresolved endpoints.
- Verified the Flask `app` can be imported and its `url_map` enumerates the newly added `update_complaints_bulk` endpoint (script succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da442566b4832aa8173987295ff855)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bulk complaint management now available—select multiple complaints and resolve or delete them in one action with confirmation of items processed.

* **Chores**
  * Updated internal application configuration for improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->