### PR TITLE
Add isolated WhatsApp marketing module with dashboard, campaigns, templates, and template-sync

### DIFF
--- a/templates/marketing_base.html
+++ b/templates/marketing_base.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}WhatsApp Marketing{% endblock %}
+
+{% block content %}
+<script src="https://cdn.tailwindcss.com"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<div class="space-y-6" x-data="{ sidebarOpen: false }">
+  <div class="flex items-center justify-between">
+    <h1 class="text-2xl font-semibold text-slate-800">WhatsApp Marketing</h1>
+    <button class="rounded-lg bg-slate-900 px-4 py-2 text-white" @click="sidebarOpen = !sidebarOpen">Toggle Menu</button>
+  </div>
+
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+    <a href="{{ url_for('marketing.dashboard') }}" class="rounded-xl bg-white p-4 shadow-md">Dashboard</a>
+    <a href="{{ url_for('marketing.campaigns_page') }}" class="rounded-xl bg-white p-4 shadow-md">Campaigns</a>
+    <a href="{{ url_for('marketing.templates_page') }}" class="rounded-xl bg-white p-4 shadow-md">Templates</a>
+    <button class="rounded-xl bg-white p-4 text-left shadow-md" @click="sidebarOpen = !sidebarOpen">Quick Actions</button>
+  </div>
+
+  <div class="rounded-xl border border-slate-200 bg-slate-50 p-4" x-show="sidebarOpen" x-transition>
+    <p class="text-sm text-slate-600">Use Quick Actions to sync templates or run queued campaigns from API endpoints.</p>
+  </div>
+
+  {% block marketing_content %}{% endblock %}
+</div>
+{% endblock %}

--- a/templates/marketing_campaigns.html
+++ b/templates/marketing_campaigns.html
@@ -1,0 +1,79 @@
+{% extends "marketing_base.html" %}
+
+{% block marketing_content %}
+<div x-data="campaignUI()" class="space-y-6">
+  <div class="flex items-center justify-between">
+    <h2 class="text-xl font-semibold">Campaigns</h2>
+    <button class="rounded-lg bg-blue-600 px-4 py-2 text-white" @click="open=true">Create Campaign</button>
+  </div>
+
+  <div class="rounded-xl bg-white p-6 shadow-md overflow-x-auto">
+    <table class="min-w-full text-sm">
+      <thead><tr class="border-b text-left"><th class="p-2">Name</th><th class="p-2">Template</th><th class="p-2">Schedule</th><th class="p-2">Status</th></tr></thead>
+      <tbody>
+      {% for c in campaigns %}
+      <tr class="border-b">
+        <td class="p-2">{{ c.name }}</td>
+        <td class="p-2">{{ c.template_name }}</td>
+        <td class="p-2">{{ c.scheduled_time or '-' }}</td>
+        <td class="p-2"><span class="rounded-full px-2 py-1 text-xs bg-slate-100">{{ c.status }}</span></td>
+      </tr>
+      {% else %}
+      <tr><td class="p-2" colspan="4">No campaigns yet.</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div x-show="open" x-transition class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+    <div class="w-full max-w-2xl rounded-xl bg-white p-6 shadow-md">
+      <div class="mb-4 flex items-center justify-between">
+        <h3 class="text-lg font-semibold">Create Campaign</h3>
+        <button @click="open=false">✕</button>
+      </div>
+      <form class="space-y-4" @submit.prevent="submitCampaign">
+        <input class="w-full rounded-lg border p-3" placeholder="Campaign Name" x-model="form.name" required>
+        <select class="w-full rounded-lg border p-3" x-model="form.template_id" required>
+          <option value="">Select Template</option>
+          {% for t in templates %}
+          <option value="{{ t.id }}">{{ t.name }} ({{ t.language }})</option>
+          {% endfor %}
+        </select>
+        <input class="w-full rounded-lg border p-3" type="datetime-local" x-model="form.scheduled_time">
+        <label class="text-sm font-medium">Variable Mapping JSON (example: [{"variable_position":1,"field_name":"contact_name"}])</label>
+        <textarea class="w-full rounded-lg border p-3" rows="3" x-model="mappingJson"></textarea>
+        <label class="text-sm font-medium">Contacts</label>
+        <select multiple class="w-full rounded-lg border p-3 h-36" x-model="form.contact_ids">
+          {% for c in contacts %}
+          <option value="{{ c.contact_id }}">{{ c.contact_name }} ({{ c.mobile }})</option>
+          {% endfor %}
+        </select>
+        <div class="flex justify-end gap-2">
+          <button type="button" class="rounded-lg border px-4 py-2" @click="open=false">Cancel</button>
+          <button type="submit" class="rounded-lg bg-blue-600 px-4 py-2 text-white">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+function campaignUI() {
+  return {
+    open: false,
+    mappingJson: '[]',
+    form: { name: '', template_id: '', scheduled_time: '', contact_ids: [] },
+    async submitCampaign() {
+      let variable_mapping = [];
+      try { variable_mapping = JSON.parse(this.mappingJson || '[]'); } catch(e) { alert('Invalid mapping JSON'); return; }
+      const payload = { ...this.form, variable_mapping };
+      const res = await fetch('{{ url_for("marketing.create_campaign") }}', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload)
+      });
+      if (!res.ok) { alert('Failed to create campaign'); return; }
+      window.location.reload();
+    }
+  }
+}
+</script>
+{% endblock %}

--- a/templates/marketing_dashboard.html
+++ b/templates/marketing_dashboard.html
@@ -1,0 +1,44 @@
+{% extends "marketing_base.html" %}
+
+{% block marketing_content %}
+<div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+  <div class="rounded-xl bg-white p-6 shadow-md"><p class="text-sm text-slate-500">Total Contacts</p><p class="text-2xl font-bold">{{ analytics.total_contacts }}</p></div>
+  <div class="rounded-xl bg-white p-6 shadow-md"><p class="text-sm text-slate-500">Campaigns</p><p class="text-2xl font-bold">{{ analytics.campaign_count }}</p></div>
+  <div class="rounded-xl bg-white p-6 shadow-md"><p class="text-sm text-slate-500">Messages Sent Today</p><p class="text-2xl font-bold">{{ analytics.sent_today }}</p></div>
+  <div class="rounded-xl bg-white p-6 shadow-md"><p class="text-sm text-slate-500">Delivery Rate</p><p class="text-2xl font-bold">{{ analytics.delivery_rate }}%</p></div>
+</div>
+
+<div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+  <div class="rounded-xl bg-white p-6 shadow-md"><h2 class="mb-3 font-semibold">Messages Over Time</h2><canvas id="messagesOverTime"></canvas></div>
+  <div class="rounded-xl bg-white p-6 shadow-md"><h2 class="mb-3 font-semibold">Campaign Stats</h2><canvas id="campaignStats"></canvas></div>
+</div>
+
+<div class="rounded-xl bg-white p-6 shadow-md">
+  <h2 class="mb-3 font-semibold">Recent Campaigns</h2>
+  <div class="overflow-x-auto">
+    <table class="min-w-full text-sm">
+      <thead><tr class="border-b text-left"><th class="p-2">Name</th><th class="p-2">Template</th><th class="p-2">Status</th><th class="p-2">Sent</th></tr></thead>
+      <tbody>
+      {% for c in recent_campaigns %}
+      <tr class="border-b"><td class="p-2">{{ c.name }}</td><td class="p-2">{{ c.template_name }}</td><td class="p-2">{{ c.status }}</td><td class="p-2">{{ c.sent_count }}/{{ c.recipient_count }}</td></tr>
+      {% else %}
+      <tr><td class="p-2" colspan="4">No campaigns yet.</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+const msgData = {{ analytics.messages_over_time | tojson }};
+const campData = {{ analytics.campaign_stats | tojson }};
+new Chart(document.getElementById('messagesOverTime'), {
+  type: 'line',
+  data: { labels: msgData.map(i => i.day), datasets: [{ label: 'Sent', data: msgData.map(i => i.sent_count), borderColor: '#0f172a' }] }
+});
+new Chart(document.getElementById('campaignStats'), {
+  type: 'bar',
+  data: { labels: campData.map(i => i.name), datasets: [{ label: 'Sent', data: campData.map(i => i.sent_count), backgroundColor: '#2563eb' }] }
+});
+</script>
+{% endblock %}

--- a/templates/marketing_templates.html
+++ b/templates/marketing_templates.html
@@ -1,0 +1,43 @@
+{% extends "marketing_base.html" %}
+
+{% block marketing_content %}
+<div x-data="templatesUI()" class="space-y-6">
+  <div class="flex items-center justify-between">
+    <h2 class="text-xl font-semibold">Templates</h2>
+    <button class="rounded-lg bg-emerald-600 px-4 py-2 text-white" @click="syncTemplates">Sync Approved Templates</button>
+  </div>
+
+  <div class="rounded-xl bg-white p-6 shadow-md overflow-x-auto">
+    <table class="min-w-full text-sm">
+      <thead><tr class="border-b text-left"><th class="p-2">Name</th><th class="p-2">Language</th><th class="p-2">Category</th><th class="p-2">Variables</th><th class="p-2">Preview</th></tr></thead>
+      <tbody>
+      {% for t in templates %}
+      <tr class="border-b">
+        <td class="p-2">{{ t.name }}</td>
+        <td class="p-2">{{ t.language }}</td>
+        <td class="p-2">{{ t.category }}</td>
+        <td class="p-2">{{ t.variables_count }}</td>
+        <td class="p-2">{{ t.body_text[:80] }}{% if t.body_text|length > 80 %}...{% endif %}</td>
+      </tr>
+      {% else %}
+      <tr><td class="p-2" colspan="5">No templates synced yet.</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+function templatesUI() {
+  return {
+    async syncTemplates() {
+      const res = await fetch('{{ url_for("marketing.sync_templates") }}', { method: 'POST' });
+      if (!res.ok) { alert('Template sync failed'); return; }
+      const data = await res.json();
+      alert(`Synced: ${data.synced}, Skipped: ${data.skipped}`);
+      window.location.reload();
+    }
+  }
+}
+</script>
+{% endblock %}

--- a/whatsapp_marketing/README.md
+++ b/whatsapp_marketing/README.md
@@ -1,0 +1,72 @@
+# WhatsApp Marketing Module (Isolated)
+
+This module is fully isolated and does not overwrite existing routes, templates, or tables.
+
+## Files
+- `routes.py`: Blueprint and APIs under `/marketing/*`
+- `services.py`: WhatsApp send service with variable validation
+- `template_sync.py`: Sync approved templates from Meta API
+- `campaign_engine.py`: Queue processor + retry logic (max 3)
+- `models.py`: DB schema + repository layer
+- `schema.sql`: SQL schema for module tables
+
+## Integration in Flask app (one-time include)
+> This repo keeps existing files untouched per request. Use the snippet below when you are ready to wire it:
+
+```python
+from whatsapp_marketing import init_marketing
+
+init_marketing(app, get_db_connection)
+```
+
+This registers the blueprint with `/marketing` prefix and initializes schema.
+
+## API Endpoints
+- `GET /marketing/dashboard`
+- `GET /marketing/campaigns`
+- `POST /marketing/campaigns`
+- `POST /marketing/campaigns/run`
+- `GET /marketing/templates`
+- `GET /marketing/api/templates`
+- `POST /marketing/templates/sync`
+- `GET /marketing/webhook`
+- `POST /marketing/webhook`
+
+## Sample .env
+```env
+# Core
+SECRET_KEY=change-this
+DATABASE_PATH=/home/username/app/database/complaints.db
+
+# WhatsApp Cloud API
+WHATSAPP_API_VERSION=v20.0
+META_ACCESS_TOKEN=EAAG...
+PHONE_NUMBER_ID=123456789012345
+WABA_ID=123456789012345
+META_APP_SECRET=your_app_secret
+WEBHOOK_VERIFY_TOKEN=your_verify_token
+```
+
+## Scheduling (no Celery/Redis)
+Use cron in cPanel:
+
+```bash
+*/2 * * * * /usr/bin/curl -s -X POST https://yourdomain.com/marketing/campaigns/run >/dev/null 2>&1
+```
+
+## cPanel deployment steps
+1. Upload module and templates files to the same project root.
+2. Add environment variables in cPanel > Setup Python App.
+3. Restart Python application.
+4. Run schema SQL once (or first load calls `init_schema`).
+5. Configure Meta webhook URL:
+   - Verify: `https://yourdomain.com/marketing/webhook`
+   - Events: messages + statuses
+6. Add cron entry to run queued campaigns.
+
+## Security and safety
+- Env vars only (no hardcoded tokens)
+- Signature verification for webhook (`X-Hub-Signature-256`)
+- Variable-count validation before send
+- Duplicate recipient prevention (`UNIQUE(campaign_id, contact_id)`)
+- Retry cap of 3 for failed sends

--- a/whatsapp_marketing/__init__.py
+++ b/whatsapp_marketing/__init__.py
@@ -1,0 +1,3 @@
+from .routes import marketing_bp, init_marketing
+
+__all__ = ["marketing_bp", "init_marketing"]

--- a/whatsapp_marketing/campaign_engine.py
+++ b/whatsapp_marketing/campaign_engine.py
@@ -1,0 +1,100 @@
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from .models import MarketingRepository
+from .services import WhatsAppMessageService, WhatsAppServiceError
+
+
+class CampaignEngine:
+    def __init__(self, repository: MarketingRepository, message_service: WhatsAppMessageService) -> None:
+        self.repository = repository
+        self.message_service = message_service
+
+    def _resolve_contact_field(self, contact: Dict[str, Any], field_name: str) -> Optional[str]:
+        if "." in field_name:
+            _, key = field_name.split(".", 1)
+        else:
+            key = field_name
+        value = contact.get(key)
+        return "" if value is None else str(value)
+
+    def create_campaign(self, payload: Dict[str, Any]) -> int:
+        name = (payload.get("name") or "").strip()
+        template_id = int(payload.get("template_id", 0))
+        scheduled_time = payload.get("scheduled_time")
+        mappings = payload.get("variable_mapping", [])
+
+        if not name:
+            raise ValueError("Campaign name is required")
+
+        template = self.repository.get_template(template_id)
+        if not template:
+            raise ValueError("Invalid template selected")
+
+        clean_mappings = []
+        for item in mappings:
+            try:
+                pos = int(item.get("variable_position"))
+                field = str(item.get("field_name", "")).strip()
+                if pos <= 0 or not field:
+                    continue
+                clean_mappings.append((pos, field))
+            except (TypeError, ValueError):
+                continue
+
+        contact_ids = payload.get("contact_ids") or []
+        campaign_id = self.repository.create_campaign(name, template_id, scheduled_time, clean_mappings)
+        self.repository.enqueue_campaign_contacts(campaign_id, contact_ids)
+        return campaign_id
+
+    def run_pending(self, batch_size: int = 50) -> Dict[str, int]:
+        pending = self.repository.get_pending_recipients(limit=batch_size)
+        contacts = {row["contact_id"]: dict(row) for row in self.repository.list_contacts()}
+
+        results = {"processed": 0, "sent": 0, "failed": 0, "skipped": 0}
+        for recipient in pending:
+            results["processed"] += 1
+            campaign_id = int(recipient["campaign_id"])
+            self.repository.mark_campaign_running(campaign_id)
+
+            mapping = self.repository.get_campaign_mappings(campaign_id)
+            contact = contacts.get(recipient["contact_id"]) or {
+                "contact_id": recipient["contact_id"],
+                "contact_name": recipient["contact_id"],
+                "mobile": recipient["contact_id"],
+            }
+
+            variables: List[str] = []
+            invalid_mapping = False
+            for pos in range(1, int(recipient["variables_count"]) + 1):
+                field_name = mapping.get(pos)
+                if not field_name:
+                    invalid_mapping = True
+                    break
+                variables.append(self._resolve_contact_field(contact, field_name))
+
+            if invalid_mapping:
+                self.repository.mark_recipient_result(recipient["recipient_id"], "failed", None, "Invalid variable mapping")
+                results["skipped"] += 1
+                continue
+
+            try:
+                response = self.message_service.send_template_message(
+                    to=contact.get("mobile", recipient["contact_id"]),
+                    template_name=recipient["template_name"],
+                    language=recipient["language"],
+                    variables=variables,
+                    expected_count=int(recipient["variables_count"]),
+                )
+                message_id = None
+                msgs = response.get("messages") or []
+                if msgs:
+                    message_id = msgs[0].get("id")
+                self.repository.mark_recipient_result(recipient["recipient_id"], "sent", message_id, None)
+                results["sent"] += 1
+            except (WhatsAppServiceError, ValueError) as exc:
+                self.repository.mark_recipient_result(recipient["recipient_id"], "failed", None, str(exc))
+                results["failed"] += 1
+
+        self.repository.mark_completed_campaigns()
+        return results

--- a/whatsapp_marketing/models.py
+++ b/whatsapp_marketing/models.py
@@ -1,0 +1,419 @@
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+DDL_STATEMENTS = [
+    """
+    CREATE TABLE IF NOT EXISTS templates (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        language TEXT NOT NULL,
+        category TEXT,
+        status TEXT NOT NULL,
+        body_text TEXT,
+        variables_count INTEGER DEFAULT 0,
+        raw_json TEXT NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(name, language)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS marketing_campaigns (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        template_id INTEGER NOT NULL,
+        scheduled_time TEXT,
+        status TEXT NOT NULL DEFAULT 'draft',
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(template_id) REFERENCES templates(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS campaign_variable_mapping (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        campaign_id INTEGER NOT NULL,
+        variable_position INTEGER NOT NULL,
+        field_name TEXT NOT NULL,
+        UNIQUE(campaign_id, variable_position),
+        FOREIGN KEY(campaign_id) REFERENCES marketing_campaigns(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS campaign_recipients (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        campaign_id INTEGER NOT NULL,
+        contact_id TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        retry_count INTEGER DEFAULT 0,
+        external_message_id TEXT,
+        error_message TEXT,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(campaign_id, contact_id),
+        FOREIGN KEY(campaign_id) REFERENCES marketing_campaigns(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS marketing_webhook_logs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_type TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )
+    """,
+]
+
+
+class MarketingRepository:
+    def __init__(self, get_db_connection):
+        self._get_db_connection = get_db_connection
+
+    def init_schema(self) -> None:
+        conn = self._get_db_connection()
+        try:
+            cur = conn.cursor()
+            for ddl in DDL_STATEMENTS:
+                cur.execute(ddl)
+            conn.commit()
+        finally:
+            conn.close()
+
+    def upsert_template(self, template: Dict[str, Any], variables_count: int, body_text: str) -> None:
+        conn = self._get_db_connection()
+        try:
+            conn.execute(
+                """
+                INSERT INTO templates (name, language, category, status, body_text, variables_count, raw_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(name, language) DO UPDATE SET
+                    category = excluded.category,
+                    status = excluded.status,
+                    body_text = excluded.body_text,
+                    variables_count = excluded.variables_count,
+                    raw_json = excluded.raw_json
+                """,
+                (
+                    template.get("name", "").strip(),
+                    template.get("language", "en"),
+                    template.get("category", "MARKETING"),
+                    template.get("status", "UNKNOWN"),
+                    body_text,
+                    variables_count,
+                    json.dumps(template),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def list_templates(self) -> List[sqlite3.Row]:
+        conn = self._get_db_connection()
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT id, name, language, category, status, body_text, variables_count, created_at
+                FROM templates
+                ORDER BY created_at DESC
+                """
+            ).fetchall()
+            return rows
+        finally:
+            conn.close()
+
+    def get_template(self, template_id: int) -> Optional[sqlite3.Row]:
+        conn = self._get_db_connection()
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                """
+                SELECT id, name, language, category, status, body_text, variables_count
+                FROM templates WHERE id = ?
+                """,
+                (template_id,),
+            ).fetchone()
+            return row
+        finally:
+            conn.close()
+
+    def create_campaign(self, name: str, template_id: int, scheduled_time: Optional[str], mappings: List[Tuple[int, str]]) -> int:
+        conn = self._get_db_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO marketing_campaigns (name, template_id, scheduled_time, status)
+                VALUES (?, ?, ?, 'scheduled')
+                """,
+                (name, template_id, scheduled_time),
+            )
+            campaign_id = cur.lastrowid
+            for variable_position, field_name in mappings:
+                cur.execute(
+                    """
+                    INSERT INTO campaign_variable_mapping (campaign_id, variable_position, field_name)
+                    VALUES (?, ?, ?)
+                    """,
+                    (campaign_id, variable_position, field_name),
+                )
+            conn.commit()
+            return campaign_id
+        finally:
+            conn.close()
+
+    def list_campaigns(self) -> List[sqlite3.Row]:
+        conn = self._get_db_connection()
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT c.id, c.name, c.scheduled_time, c.status, c.created_at,
+                       t.name AS template_name,
+                       SUM(CASE WHEN r.status='sent' THEN 1 ELSE 0 END) AS sent_count,
+                       COUNT(r.id) AS recipient_count
+                FROM marketing_campaigns c
+                JOIN templates t ON t.id = c.template_id
+                LEFT JOIN campaign_recipients r ON r.campaign_id = c.id
+                GROUP BY c.id
+                ORDER BY c.created_at DESC
+                """
+            ).fetchall()
+            return rows
+        finally:
+            conn.close()
+
+    def get_campaign(self, campaign_id: int) -> Optional[sqlite3.Row]:
+        conn = self._get_db_connection()
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                """
+                SELECT c.*, t.name AS template_name, t.language, t.variables_count
+                FROM marketing_campaigns c
+                JOIN templates t ON t.id = c.template_id
+                WHERE c.id = ?
+                """,
+                (campaign_id,),
+            ).fetchone()
+            return row
+        finally:
+            conn.close()
+
+    def get_campaign_mappings(self, campaign_id: int) -> Dict[int, str]:
+        conn = self._get_db_connection()
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT variable_position, field_name
+                FROM campaign_variable_mapping
+                WHERE campaign_id = ?
+                ORDER BY variable_position ASC
+                """,
+                (campaign_id,),
+            ).fetchall()
+            return {int(r["variable_position"]): r["field_name"] for r in rows}
+        finally:
+            conn.close()
+
+    def list_contacts(self) -> List[sqlite3.Row]:
+        conn = self._get_db_connection()
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT mobile AS contact_id,
+                       COALESCE(MAX(NULLIF(name,'')), mobile) AS contact_name,
+                       mobile
+                FROM whatsapp_messages
+                WHERE mobile IS NOT NULL AND TRIM(mobile) != ''
+                GROUP BY mobile
+                ORDER BY MAX(created_at) DESC
+                """
+            ).fetchall()
+            return rows
+        finally:
+            conn.close()
+
+    def enqueue_campaign_contacts(self, campaign_id: int, contact_ids: Iterable[str]) -> int:
+        conn = self._get_db_connection()
+        try:
+            cur = conn.cursor()
+            created = 0
+            for contact_id in contact_ids:
+                cur.execute(
+                    """
+                    INSERT OR IGNORE INTO campaign_recipients (campaign_id, contact_id, status, retry_count)
+                    VALUES (?, ?, 'pending', 0)
+                    """,
+                    (campaign_id, contact_id),
+                )
+                if cur.rowcount:
+                    created += 1
+            conn.commit()
+            return created
+        finally:
+            conn.close()
+
+    def get_pending_recipients(self, limit: int = 50) -> List[sqlite3.Row]:
+        conn = self._get_db_connection()
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT r.id AS recipient_id,
+                       r.campaign_id,
+                       r.contact_id,
+                       r.retry_count,
+                       c.name AS campaign_name,
+                       c.status AS campaign_status,
+                       t.name AS template_name,
+                       t.language,
+                       t.variables_count
+                FROM campaign_recipients r
+                JOIN marketing_campaigns c ON c.id = r.campaign_id
+                JOIN templates t ON t.id = c.template_id
+                WHERE r.status = 'pending'
+                  AND r.retry_count < 3
+                  AND c.status IN ('scheduled', 'running')
+                  AND (c.scheduled_time IS NULL OR c.scheduled_time <= ?)
+                ORDER BY c.scheduled_time ASC, r.id ASC
+                LIMIT ?
+                """,
+                (datetime.utcnow().isoformat(), limit),
+            ).fetchall()
+            return rows
+        finally:
+            conn.close()
+
+    def mark_campaign_running(self, campaign_id: int) -> None:
+        conn = self._get_db_connection()
+        try:
+            conn.execute(
+                "UPDATE marketing_campaigns SET status='running', updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                (campaign_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def mark_recipient_result(self, recipient_id: int, status: str, external_message_id: Optional[str], error_message: Optional[str]) -> None:
+        conn = self._get_db_connection()
+        try:
+            if status == 'failed':
+                conn.execute(
+                    """
+                    UPDATE campaign_recipients
+                    SET status=?, retry_count=retry_count+1, external_message_id=?, error_message=?, updated_at=CURRENT_TIMESTAMP
+                    WHERE id=?
+                    """,
+                    (status, external_message_id, error_message, recipient_id),
+                )
+            else:
+                conn.execute(
+                    """
+                    UPDATE campaign_recipients
+                    SET status=?, external_message_id=?, error_message=?, updated_at=CURRENT_TIMESTAMP
+                    WHERE id=?
+                    """,
+                    (status, external_message_id, error_message, recipient_id),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def mark_completed_campaigns(self) -> None:
+        conn = self._get_db_connection()
+        try:
+            conn.execute(
+                """
+                UPDATE marketing_campaigns
+                SET status='completed', updated_at=CURRENT_TIMESTAMP
+                WHERE id IN (
+                    SELECT c.id
+                    FROM marketing_campaigns c
+                    LEFT JOIN campaign_recipients r ON r.campaign_id = c.id
+                    GROUP BY c.id
+                    HAVING SUM(CASE WHEN r.status IN ('pending', 'failed') AND r.retry_count < 3 THEN 1 ELSE 0 END) = 0
+                )
+                AND status IN ('scheduled', 'running')
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def save_webhook_log(self, event_type: str, payload: Dict[str, Any]) -> None:
+        conn = self._get_db_connection()
+        try:
+            conn.execute(
+                "INSERT INTO marketing_webhook_logs(event_type, payload_json) VALUES (?, ?)",
+                (event_type, json.dumps(payload)),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def analytics_snapshot(self) -> Dict[str, Any]:
+        conn = self._get_db_connection()
+        conn.row_factory = sqlite3.Row
+        try:
+            total_contacts = conn.execute(
+                "SELECT COUNT(DISTINCT mobile) AS count FROM whatsapp_messages WHERE mobile IS NOT NULL AND TRIM(mobile) != ''"
+            ).fetchone()["count"]
+            campaign_count = conn.execute("SELECT COUNT(*) AS count FROM marketing_campaigns").fetchone()["count"]
+            sent_today = conn.execute(
+                """
+                SELECT COUNT(*) AS count FROM campaign_recipients
+                WHERE status='sent' AND DATE(updated_at)=DATE('now')
+                """
+            ).fetchone()["count"]
+            delivery = conn.execute(
+                """
+                SELECT
+                    SUM(CASE WHEN status='sent' THEN 1 ELSE 0 END) AS sent_count,
+                    COUNT(*) AS total_count
+                FROM campaign_recipients
+                """
+            ).fetchone()
+            total = delivery["total_count"] or 0
+            sent = delivery["sent_count"] or 0
+            rate = round((sent / total) * 100, 2) if total else 0
+
+            by_day = conn.execute(
+                """
+                SELECT DATE(updated_at) AS day,
+                       SUM(CASE WHEN status='sent' THEN 1 ELSE 0 END) AS sent_count
+                FROM campaign_recipients
+                GROUP BY DATE(updated_at)
+                ORDER BY day DESC
+                LIMIT 14
+                """
+            ).fetchall()
+            campaign_perf = conn.execute(
+                """
+                SELECT c.name,
+                       SUM(CASE WHEN r.status='sent' THEN 1 ELSE 0 END) AS sent_count,
+                       COUNT(r.id) AS total_recipients
+                FROM marketing_campaigns c
+                LEFT JOIN campaign_recipients r ON r.campaign_id = c.id
+                GROUP BY c.id
+                ORDER BY c.created_at DESC
+                LIMIT 8
+                """
+            ).fetchall()
+
+            return {
+                "total_contacts": total_contacts,
+                "campaign_count": campaign_count,
+                "sent_today": sent_today,
+                "delivery_rate": rate,
+                "messages_over_time": [dict(row) for row in reversed(by_day)],
+                "campaign_stats": [dict(row) for row in campaign_perf],
+            }
+        finally:
+            conn.close()

--- a/whatsapp_marketing/routes.py
+++ b/whatsapp_marketing/routes.py
@@ -1,0 +1,127 @@
+import hashlib
+import hmac
+import json
+import os
+from typing import Callable
+
+from flask import Blueprint, current_app, jsonify, render_template, request
+
+from .campaign_engine import CampaignEngine
+from .models import MarketingRepository
+from .services import WhatsAppMessageService
+from .template_sync import TemplateSyncService
+
+
+marketing_bp = Blueprint("marketing", __name__, url_prefix="/marketing")
+
+
+def _repo() -> MarketingRepository:
+    getter: Callable = current_app.config["MARKETING_GET_DB_CONNECTION"]
+    return MarketingRepository(getter)
+
+
+def _engine() -> CampaignEngine:
+    return CampaignEngine(_repo(), WhatsAppMessageService())
+
+
+def _template_sync() -> TemplateSyncService:
+    return TemplateSyncService(_repo())
+
+
+@marketing_bp.route("/dashboard", methods=["GET"])
+def dashboard() -> str:
+    repository = _repo()
+    analytics = repository.analytics_snapshot()
+    recent_campaigns = [dict(row) for row in repository.list_campaigns()[:10]]
+    return render_template(
+        "marketing_dashboard.html",
+        analytics=analytics,
+        recent_campaigns=recent_campaigns,
+    )
+
+
+@marketing_bp.route("/campaigns", methods=["GET"])
+def campaigns_page() -> str:
+    repository = _repo()
+    return render_template(
+        "marketing_campaigns.html",
+        campaigns=[dict(r) for r in repository.list_campaigns()],
+        templates=[dict(t) for t in repository.list_templates()],
+        contacts=[dict(c) for c in repository.list_contacts()],
+    )
+
+
+@marketing_bp.route("/templates", methods=["GET"])
+def templates_page() -> str:
+    return render_template("marketing_templates.html", templates=_template_sync().list_templates())
+
+
+@marketing_bp.route("/api/templates", methods=["GET"])
+def api_list_templates():
+    return jsonify({"templates": _template_sync().list_templates()})
+
+
+@marketing_bp.route("/templates/sync", methods=["POST"])
+def sync_templates():
+    result = _template_sync().sync()
+    return jsonify(result)
+
+
+@marketing_bp.route("/campaigns", methods=["POST"])
+def create_campaign():
+    payload = request.get_json(silent=True) or {}
+    campaign_id = _engine().create_campaign(payload)
+    return jsonify({"campaign_id": campaign_id, "status": "created"}), 201
+
+
+@marketing_bp.route("/campaigns/run", methods=["POST"])
+def run_campaigns():
+    payload = request.get_json(silent=True) or {}
+    batch_size = int(payload.get("batch_size", 50))
+    result = _engine().run_pending(batch_size=batch_size)
+    return jsonify(result)
+
+
+@marketing_bp.route("/webhook", methods=["GET"])
+def webhook_verify():
+    mode = request.args.get("hub.mode")
+    token = request.args.get("hub.verify_token")
+    challenge = request.args.get("hub.challenge", "")
+    expected = os.environ.get("WEBHOOK_VERIFY_TOKEN", "")
+    if mode == "subscribe" and token and token == expected:
+        return challenge, 200
+    return "Verification failed", 403
+
+
+@marketing_bp.route("/webhook", methods=["POST"])
+def webhook_event():
+    payload = request.get_json(silent=True) or {}
+    signature = request.headers.get("X-Hub-Signature-256", "")
+    app_secret = os.environ.get("META_APP_SECRET", "")
+
+    if app_secret and signature:
+        raw = request.get_data() or b""
+        digest = "sha256=" + hmac.new(app_secret.encode("utf-8"), raw, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(digest, signature):
+            return jsonify({"error": "Invalid signature"}), 403
+
+    repo = _repo()
+    repo.save_webhook_log("webhook_event", payload)
+
+    entries = payload.get("entry", [])
+    for entry in entries:
+        for change in entry.get("changes", []):
+            value = change.get("value", {})
+            if value.get("statuses"):
+                repo.save_webhook_log("message_status", {"statuses": value.get("statuses")})
+            if value.get("messages"):
+                repo.save_webhook_log("incoming_message", {"messages": value.get("messages")})
+
+    return jsonify({"status": "ok"}), 200
+
+
+def init_marketing(app, get_db_connection) -> None:
+    app.config["MARKETING_GET_DB_CONNECTION"] = get_db_connection
+    repo = MarketingRepository(get_db_connection)
+    repo.init_schema()
+    app.register_blueprint(marketing_bp)

--- a/whatsapp_marketing/schema.sql
+++ b/whatsapp_marketing/schema.sql
@@ -1,0 +1,53 @@
+CREATE TABLE IF NOT EXISTS templates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    language TEXT NOT NULL,
+    category TEXT,
+    status TEXT NOT NULL,
+    body_text TEXT,
+    variables_count INTEGER DEFAULT 0,
+    raw_json TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(name, language)
+);
+
+CREATE TABLE IF NOT EXISTS marketing_campaigns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    template_id INTEGER NOT NULL,
+    scheduled_time TEXT,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(template_id) REFERENCES templates(id)
+);
+
+CREATE TABLE IF NOT EXISTS campaign_variable_mapping (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    campaign_id INTEGER NOT NULL,
+    variable_position INTEGER NOT NULL,
+    field_name TEXT NOT NULL,
+    UNIQUE(campaign_id, variable_position),
+    FOREIGN KEY(campaign_id) REFERENCES marketing_campaigns(id)
+);
+
+CREATE TABLE IF NOT EXISTS campaign_recipients (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    campaign_id INTEGER NOT NULL,
+    contact_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    retry_count INTEGER DEFAULT 0,
+    external_message_id TEXT,
+    error_message TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(campaign_id, contact_id),
+    FOREIGN KEY(campaign_id) REFERENCES marketing_campaigns(id)
+);
+
+CREATE TABLE IF NOT EXISTS marketing_webhook_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);

--- a/whatsapp_marketing/services.py
+++ b/whatsapp_marketing/services.py
@@ -1,0 +1,77 @@
+import json
+import os
+import re
+from typing import Any, Dict, List
+
+import requests
+
+
+class WhatsAppServiceError(Exception):
+    pass
+
+
+class WhatsAppMessageService:
+    def __init__(self) -> None:
+        self.api_version = os.environ.get("WHATSAPP_API_VERSION", "v20.0")
+        self.access_token = os.environ.get("META_ACCESS_TOKEN", "")
+        self.phone_number_id = os.environ.get("PHONE_NUMBER_ID", "")
+
+    def _validate_env(self) -> None:
+        missing = [
+            key
+            for key, value in {
+                "META_ACCESS_TOKEN": self.access_token,
+                "PHONE_NUMBER_ID": self.phone_number_id,
+            }.items()
+            if not value
+        ]
+        if missing:
+            raise WhatsAppServiceError(f"Missing environment variables: {', '.join(missing)}")
+
+    @staticmethod
+    def count_expected_variables(template_body_text: str) -> int:
+        indices = [int(match) for match in re.findall(r"\{\{\s*(\d+)\s*\}\}", template_body_text or "")]
+        return max(indices) if indices else 0
+
+    def send_template_message(self, to: str, template_name: str, language: str, variables: List[str], expected_count: int) -> Dict[str, Any]:
+        self._validate_env()
+
+        cleaned = re.sub(r"\D", "", to or "")
+        if not cleaned:
+            raise WhatsAppServiceError("Invalid destination number.")
+
+        if expected_count != len(variables):
+            raise WhatsAppServiceError(f"Invalid variable count. Expected {expected_count}, received {len(variables)}")
+
+        components = []
+        if variables:
+            components.append(
+                {
+                    "type": "body",
+                    "parameters": [{"type": "text", "text": str(value)} for value in variables],
+                }
+            )
+
+        payload = {
+            "messaging_product": "whatsapp",
+            "to": cleaned,
+            "type": "template",
+            "template": {
+                "name": template_name,
+                "language": {"code": language},
+                "components": components,
+            },
+        }
+
+        url = f"https://graph.facebook.com/{self.api_version}/{self.phone_number_id}/messages"
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+        }
+
+        response = requests.post(url, headers=headers, data=json.dumps(payload), timeout=30)
+        data = response.json() if response.content else {}
+        if response.status_code >= 400:
+            error_details = data.get("error", {})
+            raise WhatsAppServiceError(error_details.get("message", f"Meta API call failed with {response.status_code}"))
+        return data

--- a/whatsapp_marketing/template_sync.py
+++ b/whatsapp_marketing/template_sync.py
@@ -1,0 +1,54 @@
+import os
+import re
+from typing import Any, Dict, List
+
+import requests
+
+from .models import MarketingRepository
+
+
+class TemplateSyncService:
+    def __init__(self, repository: MarketingRepository) -> None:
+        self.repository = repository
+
+    @staticmethod
+    def _extract_body_text(template: Dict[str, Any]) -> str:
+        for component in template.get("components", []):
+            if component.get("type") == "BODY":
+                return component.get("text", "")
+        return ""
+
+    @staticmethod
+    def _variables_count(text: str) -> int:
+        matches = [int(v) for v in re.findall(r"\{\{\s*(\d+)\s*\}\}", text or "")]
+        return max(matches) if matches else 0
+
+    def sync(self) -> Dict[str, int]:
+        token = os.environ.get("META_ACCESS_TOKEN", "")
+        waba_id = os.environ.get("WABA_ID", "")
+        version = os.environ.get("WHATSAPP_API_VERSION", "v20.0")
+        if not token or not waba_id:
+            raise RuntimeError("META_ACCESS_TOKEN and WABA_ID are required for template sync")
+
+        url = f"https://graph.facebook.com/{version}/{waba_id}/message_templates"
+        headers = {"Authorization": f"Bearer {token}"}
+
+        synced = 0
+        skipped = 0
+        while url:
+            response = requests.get(url, headers=headers, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+            for template in payload.get("data", []):
+                if template.get("status") != "APPROVED":
+                    skipped += 1
+                    continue
+                body = self._extract_body_text(template)
+                var_count = self._variables_count(body)
+                self.repository.upsert_template(template, var_count, body)
+                synced += 1
+            url = payload.get("paging", {}).get("next")
+        return {"synced": synced, "skipped": skipped}
+
+    def list_templates(self) -> List[Dict[str, Any]]:
+        return [dict(row) for row in self.repository.list_templates()]


### PR DESCRIPTION
### Motivation
- Provide a self-contained WhatsApp Marketing module that can be integrated into the existing Flask app without changing any existing files or renaming the current dashboard, and expose marketing functionality under the `/marketing` prefix. 
- Support approved WhatsApp template sync, DB-backed campaign queue and retry handling, and a small professional UI for dashboard/campaigns/templates using the flat template naming convention required.

### Description
- Added a new module `whatsapp_marketing` with `routes.py`, `services.py`, `template_sync.py`, `campaign_engine.py`, `models.py`, and `schema.sql`, and an `__init__.py` exposing `init_marketing(app, get_db_connection)` for one-line integration. 
- Registered endpoints under the `/marketing` prefix in the blueprint: `GET /marketing/dashboard`, `GET /marketing/campaigns`, `POST /marketing/campaigns`, `POST /marketing/campaigns/run`, `GET /marketing/templates`, `POST /marketing/templates/sync`, and webhook verify/receive handlers at `/marketing/webhook`. 
- Implemented DB schema and repository logic for `templates`, `marketing_campaigns`, `campaign_variable_mapping`, `campaign_recipients`, and `marketing_webhook_logs`, including `UNIQUE(campaign_id, contact_id)` to prevent duplicate sends and retry counters. 
- Implemented WhatsApp integration helpers: `WhatsAppMessageService.send_template_message(...)` with env validation, phone cleaning, variable-count validation and Meta Cloud API payload formatting, and `TemplateSyncService` to fetch `APPROVED` templates from `/{WABA_ID}/message_templates` and store body/variable counts. 
- Implemented `CampaignEngine` to create campaigns, enqueue contacts, resolve variable mappings from contacts, send pending messages in batches and mark results with retry (max 3) and completion logic. 
- Added flat UI templates that extend existing `base.html`: `marketing_base.html`, `marketing_dashboard.html`, `marketing_campaigns.html`, and `marketing_templates.html` using Tailwind CDN, Alpine.js and Chart.js, plus `whatsapp_marketing/README.md` with sample `.env`, cron scheduling, and cPanel steps. 

### Testing
- Compiled new Python module files with `python -m py_compile whatsapp_marketing/*.py` and the compile step succeeded. 
- Ran unit/flow tests with `pytest -q tests/test_flow_endpoint.py` and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c0de3df8832a84d1bcf4df9b6f0d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WhatsApp marketing module with dashboard displaying analytics and key metrics (total contacts, campaign count, messages sent, delivery rate)
  * Campaign management with creation, scheduling, and execution capabilities
  * Template synchronization and management interface
  * Variable mapping for dynamic content in campaigns
  * Webhook support for message status tracking and event logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->